### PR TITLE
🐛 Fix pseudo absolute XY

### DIFF
--- a/src/parser/pseudoShape.ts
+++ b/src/parser/pseudoShape.ts
@@ -5,21 +5,27 @@ import { isVisibleShape } from '../utils/visibility';
 /**
  * 解析图形类伪类
  */
-// eslint-disable-next-line consistent-return
 export const parsePseudoToShape = async (
   node: Element,
   pseudoElt: 'before' | 'after',
 ) => {
   // 判断一下是否有伪类
   const pseudoEl: CSSStyleDeclaration = getComputedStyle(node, `:${pseudoElt}`);
+  const bcr = node.getBoundingClientRect();
+  const { left, top, height, width } = bcr;
+  let x = left;
+  let y = top;
 
   const pseudoW = parseFloat(pseudoEl.width);
   const pseudoH = parseFloat(pseudoEl.height);
 
-  const bcr = node.getBoundingClientRect();
-  const { x, y, height, width } = bcr;
-
   const rect = await parseToShape(node, pseudoEl);
+
+  // 如果采用绝对定位的话
+  if (pseudoEl.position === 'absolute') {
+    x += parseFloat(pseudoEl.left);
+    y += parseFloat(pseudoEl.top);
+  }
 
   rect.frame = new Frame({
     width: pseudoW !== width ? pseudoW : width,


### PR DESCRIPTION
修复 Tabs 组件的描边解析问题

![image](https://user-images.githubusercontent.com/28616219/93029106-5c50ca00-f64b-11ea-9853-1686f639c6e7.png)


该描边采用伪类的绝对定位实现，因此需要额外加一些相关参数

- [ ] 还需要补充一下测试用例